### PR TITLE
Update to draft 03, request-line -> request-target

### DIFF
--- a/api/src/main/java/net/adamcin/httpsig/api/Constants.java
+++ b/api/src/main/java/net/adamcin/httpsig/api/Constants.java
@@ -65,7 +65,7 @@ public final class Constants {
      */
     public static final String KEY_ID = "keyId";
 
-    public static final String HEADER_REQUEST_LINE = "request-line";
+    public static final String HEADER_REQUEST_LINE = "request-target";
 
     public static final String HEADER_DATE = "date";
 

--- a/api/src/main/java/net/adamcin/httpsig/api/RequestContent.java
+++ b/api/src/main/java/net/adamcin/httpsig/api/RequestContent.java
@@ -196,7 +196,7 @@ public final class RequestContent implements Serializable {
 
     /**
      * @return the list of header names contained in this {@link RequestContent}, in the order in which they were added, except
-     *         for request-line, which is listed first if present
+     *         for request-target, which is listed first if present
      */
     public List<String> getHeaderNames() {
         List<String> headerNames = new ArrayList<String>();
@@ -209,7 +209,7 @@ public final class RequestContent implements Serializable {
 
 
     /**
-     * @return the request-line if set
+     * @return the request-target if set
      */
     public String getRequestLine() {
         return requestLine;


### PR DESCRIPTION
Draft 03 was released. The request-line header was renamed to request-target.

http://tools.ietf.org/html/draft-cavage-http-signatures-03
